### PR TITLE
NAS-115080 / 22.12 / fix SAS (TCG/Enterprise) detection on SCALE

### DIFF
--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -67,7 +67,7 @@ bool DtaDevLinuxSata::init(const char * devref)
     LOG(D1) << "Creating DtaDevLinuxSata::DtaDev() " << devref;
 	bool isOpen = FALSE;
 
-    if(access("/dev/sda", R_OK | W_OK)) {
+    if (access(devref, R_OK | W_OK)) {
         LOG(E) << "You do not have permission to access the raw disk in write mode";
         LOG(E) << "Perhaps you might try sudo to run as root";
     }

--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -271,6 +271,9 @@ void DtaDevLinuxSata::identify(OPAL_DiskInfo& disk_info)
 
     if (!(memcmp(nullz.data(), buffer, 512))) {
         disk_info.devType = DEVICE_TYPE_OTHER;
+        // XXX: ioctl call was aborted or returned no data, most probably
+        //      due to driver not being libata based, let's try SAS instead.
+        identify_SAS(&disk_info);
         return;
     }
     IDENTIFY_RESPONSE * id = (IDENTIFY_RESPONSE *) buffer;


### PR DESCRIPTION
Fix 2 problems:

1. SAS (TCG/Enterprise) detection is broken on SCALE (`sedutil-cli --scan` doesn't detect SED drives)
2. remove hard-coded `/dev/sda`