### PR TITLE
NAS-117273: Linux: Improve SG_IO error handling.

### DIFF
--- a/Common/DtaStructures.h
+++ b/Common/DtaStructures.h
@@ -572,6 +572,8 @@ typedef struct _IDENTIFY_RESPONSE {
     uint8_t reserved3[6];
     uint8_t firmwareRev[8];
     uint8_t modelNum[40];
+    uint16_t sectors_intr;
+    uint16_t tcg;
 } IDENTIFY_RESPONSE;
 
 


### PR DESCRIPTION
I am not sure how it worked before, may be previous Linux kernels
reported device errors as ioctl errors, but at least now it is no so.
Extend error handling to SCSI, driver and host statuses, that fixes
SAS disks operation, since otherwise due to lack of error handling
for IDENTIFY request they were incorrectly handled as SATA.

While there, alike to FreeBSD add check for TCG bit in ATA IDENTIFY
data to avoid unneeded unsupported commands errors later.