### PR TITLE
NAS-112550 / 23.10 / fix multiple problems with sedutil-cli binary

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,13 +7,14 @@ export DH_VERBOSE = 1
 override_dh_auto_build:
 	sh -c "\
 		cd linux/CLI || exit 1; \
-		gmake || exit 1; \
+		gmake CONF=Release_x86_64 || exit 1; \
 	"
 
 override_dh_auto_install:
 	sh -c "\
 		mkdir -p debian/sedutil/usr/local/bin; \
-		cp -a linux/CLI/dist/Debug_i686/GNU-Linux/sedutil-cli debian/sedutil/usr/local/bin/; \
+		strip -s linux/CLI/dist/Release_x86_64/GNU-Linux/sedutil-cli; \
+		cp -a linux/CLI/dist/Release_x86_64/GNU-Linux/sedutil-cli debian/sedutil/usr/local/bin/; \
 	"
 
 override_dh_shlibdeps:


### PR DESCRIPTION
This fixes the following problems:
1. don't build debug symbol version of the binary by default
2. don't build 32bit elf

Build 64bit release version and strip the binary of unwanted symbols.