### PR TITLE
[23.10-BETA.1] Add matches for sdXYZ and nvmeXYZ during Linux scan.

### DIFF
--- a/linux/DtaDevOS.cpp
+++ b/linux/DtaDevOS.cpp
@@ -135,9 +135,12 @@ int  DtaDevOS::diskScan()
     if(dir!=NULL)
     {
         while((dirent=readdir(dir))!=NULL) {
-            if((!fnmatch("sd[a-z]",dirent->d_name,0)) || 
+            if((!fnmatch("sd[a-z]",dirent->d_name,0)) ||
+                    (!fnmatch("sd[a-z][a-z]",dirent->d_name,0)) ||
+                    (!fnmatch("sd[a-z][a-z][a-z]",dirent->d_name,0)) ||
                     (!fnmatch("nvme[0-9]",dirent->d_name,0)) ||
-                    (!fnmatch("nvme[0-9][0-9]",dirent->d_name,0))
+                    (!fnmatch("nvme[0-9][0-9]",dirent->d_name,0)) ||
+                    (!fnmatch("nvme[0-9][0-9][0-9]",dirent->d_name,0))
                     ) {
                 tempstring = dirent->d_name;
                 devices.push_back(tempstring);


### PR DESCRIPTION
The sedutil scan currently does not display drives other than sdX. In this commit, we extend the scan to include sdXYZ and, while we're at it, also add the scan for nvmeXYZ drives.