### PR TITLE
NAS-133445 / 25.04 / Optimize device open logic to reduce udev rescans

### DIFF
--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -35,8 +35,13 @@ typedef enum _sedutiloutput {
 #define FORCE_DEV_NVME     1
 #define FORCE_DEV_SCSI     2
 
+#define DEV_STATE_READ     0
+#define DEV_STATE_QUERY    1
+#define DEV_STATE_RW       2
+
 extern uint8_t g_force_dev; /** force device type */
 extern uint8_t g_compat_bsd; /** force FreeBSD compatibility with Linux */
+extern uint8_t g_dev_state; /** device state */
 
 /** Structure representing the command line issued to the program */
 typedef struct _DTA_OPTIONS {

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -64,6 +64,11 @@ int main(int argc, char * argv[])
 		return DTAERROR_COMMAND_ERROR;
 	}
 	
+	/*
+	 * tempDev, scan, validatePBKDF2, and isValidSED should
+	 * be opened as ReadOnly
+	 */
+	g_dev_state = DEV_STATE_READ;
 	if ((opts.action != sedutiloption::scan) && 
 		(opts.action != sedutiloption::validatePBKDF2) &&
 		(opts.action != sedutiloption::isValidSED)) {
@@ -78,6 +83,14 @@ int main(int argc, char * argv[])
 			delete tempDev;
 			return DTAERROR_COMMAND_ERROR;
 		}
+
+		/*
+		 * If we are not querying, open device as RW
+		 */
+		if (opts.action == sedutiloption::query)
+			g_dev_state = DEV_STATE_QUERY;
+		else
+			g_dev_state = DEV_STATE_RW;
 		if (tempDev->isRuby1())
 			d = new DtaDevRuby1(argv[opts.device]);
 		else if (tempDev->isOpal2())

--- a/linux/DtaDevLinuxDrive.h
+++ b/linux/DtaDevLinuxDrive.h
@@ -25,15 +25,6 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 class DtaDevLinuxDrive {
 public:
     virtual ~DtaDevLinuxDrive( void ) {};
-    /**Initialization.
-     * This function should perform the necessary authority and environment checking
-     * to allow proper functioning of the program, open the device, perform an ATA
-     * identify, add the fields from the identify response to the disk info structure
-     * and if the device is an ATA device perform a call to Discovery0() to complete
-     * the disk_info structure
-     * @param devref character representation of the device is standard OS lexicon
-     */
-    virtual bool init(const char * devref) = 0;
     /** Method to send a command to the device
      * @param cmd command to be sent to the device
      * @param protocol security protocol to be used in the command
@@ -45,4 +36,5 @@ public:
             void * buffer, uint32_t bufferlen) = 0;
     /** Routine to send an identify to the device */
     virtual void identify(OPAL_DiskInfo& disk_info) = 0;
+    int fd;
 };

--- a/linux/DtaDevLinuxNvme.cpp
+++ b/linux/DtaDevLinuxNvme.cpp
@@ -44,27 +44,6 @@ using namespace std;
  */
 DtaDevLinuxNvme::DtaDevLinuxNvme() {}
 
-bool DtaDevLinuxNvme::init(const char * devref)
-{
-    LOG(D1) << "Creating DtaDevLinuxNvme::DtaDev() " << devref;
-    ifstream kopts;
-    bool isOpen = FALSE;
-
-    if ((fd = open(devref, O_RDWR)) < 0) {
-        isOpen = FALSE;
-        // This is a D1 because diskscan looks for open fail to end scan
-        LOG(D1) << "Error opening device " << devref << " " << (int32_t) fd;
-        if (-EPERM == fd) {
-            LOG(E) << "You do not have permission to access the raw disk in write mode";
-            LOG(E) << "Perhaps you might try sudo to run as root";
-        }
-    }
-    else {
-        isOpen = TRUE;
-    }
-	return isOpen;
-}
-
 /** Send an ioctl to the device using nvme admin commands. */
 uint8_t DtaDevLinuxNvme::sendCmd(ATACOMMAND cmd, uint8_t protocol, uint16_t comID,
                          void * buffer, uint32_t bufferlen)
@@ -161,5 +140,4 @@ bool DtaDevLinuxNvme::isNVMe()
 DtaDevLinuxNvme::~DtaDevLinuxNvme()
 {
     LOG(D1) << "Destroying DtaDevLinuxNvme";
-    close(fd);
 }

--- a/linux/DtaDevLinuxNvme.h
+++ b/linux/DtaDevLinuxNvme.h
@@ -39,15 +39,6 @@ public:
     DtaDevLinuxNvme();
     /** Destructor */
     ~DtaDevLinuxNvme();
-    /** NVMe specific initialization.
-     * This function should perform the necessary authority and environment checking
-     * to allow proper functioning of the program, open the device, perform an ATA
-     * identify, add the fields from the identify response to the disk info structure
-     * and if the device is an ATA device perform a call to Discovery0() to complete
-     * the disk_info structure
-     * @param devref character representation of the device is standard OS lexicon
-     */
-    bool init(const char * devref);
     /** NVMe specific method to send a command to the device
      * @param cmd command to be sent to the device
      * @param protocol security protocol to be used in the command
@@ -61,5 +52,4 @@ public:
     void identify(OPAL_DiskInfo& disk_info);
     /** Routine to check NVMe dev type without going to device */
     bool isNVMe();
-    int fd; /**< Linux handle for the device  */
 };

--- a/linux/DtaDevLinuxSata.cpp
+++ b/linux/DtaDevLinuxSata.cpp
@@ -63,31 +63,6 @@ DtaDevLinuxSata::DtaDevLinuxSata() {
 isSAS = 0;
 }
 
-bool DtaDevLinuxSata::init(const char * devref)
-{
-    LOG(D1) << "Creating DtaDevLinuxSata::DtaDev() " << devref;
-	bool isOpen = FALSE;
-
-    if (access(devref, R_OK | W_OK)) {
-        LOG(E) << "You do not have permission to access the raw disk in write mode";
-        LOG(E) << "Perhaps you might try sudo to run as root";
-    }
-
-    if ((fd = open(devref, O_RDWR)) < 0) {
-        isOpen = FALSE;
-        // This is a D1 because diskscan looks for open fail to end scan
-        LOG(D1) << "Error opening device " << devref << " " << (int32_t) fd;
-        //        if (-EPERM == fd) {
-        //            LOG(E) << "You do not have permission to access the raw disk in write mode";
-        //            LOG(E) << "Perhaps you might try sudo to run as root";
-        //        }
-    }
-    else {
-        isOpen = TRUE;
-    }
-	return isOpen;
-}
-
 /*
  * Determines if the transport for the given file descriptor `fd` is SATA.
  *
@@ -678,5 +653,4 @@ void DtaDevLinuxSata::identify_SAS(OPAL_DiskInfo *disk_info)
 DtaDevLinuxSata::~DtaDevLinuxSata()
 {
     LOG(D1) << "Destroying DtaDevLinuxSata";
-    close(fd);
 }

--- a/linux/DtaDevLinuxSata.h
+++ b/linux/DtaDevLinuxSata.h
@@ -31,15 +31,6 @@ public:
     DtaDevLinuxSata();
     /** Destructor */
     ~DtaDevLinuxSata();
-    /** Sata Linux specific initialization.
-     * This function should perform the necessary authority and environment checking
-     * to allow proper functioning of the program, open the device, perform an ATA
-     * identify, add the fields from the identify response to the disk info structure
-     * and if the device is an ATA device perform a call to Discovery0() to complete
-     * the disk_info structure
-     * @param devref character representation of the device is standard OS lexicon
-     */
-    bool init(const char * devref);
     /** Sata Linux specific method to send an ATA command to the device
      * @param cmd ATA command to be sent to the device
      * @param protocol security protocol to be used in the command
@@ -55,6 +46,5 @@ public:
             void * buffer, uint32_t bufferlen);
     /** Linux specific routine to send an ATA identify to the device */
     void identify_SAS(OPAL_DiskInfo *disk_info);
-    int fd; /**< Linux handle for the device  */
     int isSAS; /* The device is sas */
 };

--- a/linux/DtaDevOS.cpp
+++ b/linux/DtaDevOS.cpp
@@ -18,6 +18,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #include "os.h"
+#include "sys/file.h"
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>
@@ -41,6 +42,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace std;
 uint8_t g_force_dev = FORCE_DEV_NONE;
+uint8_t g_dev_state = DEV_STATE_READ;
 
 /** The Device class represents a Linux generic storage device.
   * At initialization we determine if we map to the NVMe or SATA derived class
@@ -51,18 +53,40 @@ unsigned long long DtaDevOS::getSize()
 DtaDevOS::DtaDevOS()
 {
 	drive = NULL;
+	isLocked = 0;
 }
 
 /* Determine which type of drive we're using and instantiate a derived class of that type */
 void DtaDevOS::init(const char * devref)
 {
 	LOG(D1) << "DtaDevOS::init " << devref;
-	DtaDevLinuxNvme *nvmeDrive = new DtaDevLinuxNvme();
-	bool drive_init = false;
+	DtaDevLinuxNvme *nvmeDrive;
+	int oflag = ((g_dev_state == DEV_STATE_RW) ? O_RDWR : O_RDONLY);
 
+	/*
+	 * Ensure the current user has read and write access to the disk.
+	 * Note: SED operations (through IOCTLs) require root privileges.
+	 */
+	if (access(devref, R_OK | W_OK)) {
+		LOG(E) << "Insufficient permissions for SED operations.";
+		LOG(E) << "Please try sudo to run as root";
+		isOpen = FALSE;
+		return;
+	}
+	if ((fd = open(devref, oflag)) < 0) {
+		LOG(D1) << "Error opening device " << devref << " " << (int32_t) fd;
+		isOpen = FALSE;
+		return;
+	}
+	if (g_dev_state != DEV_STATE_READ) {
+		isLocked = 1;
+		flock(fd, LOCK_EX);
+	}
+
+	nvmeDrive = new DtaDevLinuxNvme();
+	nvmeDrive->fd = fd;
 	memset(&disk_info, 0, sizeof(OPAL_DiskInfo));
 	dev = devref;
-
 	if (g_force_dev == FORCE_DEV_NVME)
 	{
 		drive = nvmeDrive;
@@ -71,10 +95,10 @@ void DtaDevOS::init(const char * devref)
 	{
 		delete nvmeDrive;
 		drive = new DtaDevLinuxSata();
+		drive->fd = fd;
 	}
-	else if (nvmeDrive->init(devref) && nvmeDrive->isNVMe())
+	else if (nvmeDrive->isNVMe())
 	{
-		drive_init = true;
 		drive = nvmeDrive;
 	}
 	else if (!strncmp(devref, "/dev/nvme", 9))
@@ -85,6 +109,7 @@ void DtaDevOS::init(const char * devref)
 	{
 		delete nvmeDrive;
 		drive = new DtaDevLinuxSata();
+		drive->fd = fd;
 	}
 	else 
         {
@@ -94,15 +119,10 @@ void DtaDevOS::init(const char * devref)
                 return;
         }
 
-	if (drive_init || drive->init(devref))
-	{
-		isOpen = TRUE;
-		drive->identify(disk_info);
-		if (disk_info.devType != DEVICE_TYPE_OTHER)
-			discovery0();
-	}
-	else
-		isOpen = FALSE;
+	isOpen = TRUE;
+	drive->identify(disk_info);
+	if (disk_info.devType != DEVICE_TYPE_OTHER)
+		discovery0();
 
 	return;
 }
@@ -190,7 +210,10 @@ int  DtaDevOS::diskScan()
 /** Close the device reference so this object can be delete. */
 DtaDevOS::~DtaDevOS()
 {
-    LOG(D1) << "Destroying DtaDevOS";
+	LOG(D1) << "Destroying DtaDevOS";
+	if (isLocked)
+		flock(fd, LOCK_UN);
+	close(fd);
 	if (NULL != drive)
 		delete drive;
 }

--- a/linux/DtaDevOS.h
+++ b/linux/DtaDevOS.h
@@ -59,6 +59,7 @@ protected:
     /** return drive size in bytes */
     unsigned long long getSize();
     int fd; /**< Linux handle for the device  */
+    int isLocked; /** device has LOCK_EX */
 private:
     /** OS specific routine to send a SCSI INQUIRY to the device */
     void identify_SAS();


### PR DESCRIPTION
Disks are currently opened with WRITE access multiple times during each SED operation, leading to excessive udev rescan events upon close. These rescans result in the deletion and recreation of device/partition symlinks, increasing the chances of race conditions.

For locked disks, querying and unlocking operations experience delays of 5–6 seconds due to the excessive udev events. Additionally, concurrent access to the same disk often fails because the sedutil tool lacks device-level locking.

This patch introduces the following improvements:
- Ensure the device is opened with WRITE access only when necessary and not more than once.
- Use `flock` to enable concurrent access to the same disk.

With these changes:
- Query time for locked devices decrease from approximately 5 seconds to under 0.1 seconds.
- Unlock time reduce from roughly 6 seconds to around 0.6 seconds.

These optimizations should result in faster boot times when disks are required to be unlocked during the boot process.

Scale Build Testing: http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/841/artifact/.