### PR TITLE
NAS-138745 / 25.10.2 / Call BLKRRPART after unlock as udev race can miss reprobe (by ixhamza) (by bugclerk)

### DIFF
--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -114,6 +114,10 @@ public:
 	virtual void identify(OPAL_DiskInfo& disk_info) = 0;
 	/** OS specific routine to get size of the device */
 	virtual unsigned long long getSize() = 0;
+	/** Re-read partition table to make partitions visible immediately after unlock,
+	 * avoiding udev race conditions.
+	 */
+	virtual void rereadPartitionTable() {}
 	/*
 	 * virtual functions required to be implemented
 	 * because they are called by sedutil.cpp

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -146,12 +146,24 @@ int main(int argc, char * argv[])
         return d->loadPBA(argv[opts.password], argv[opts.pbafile]);
 		break;
 	case sedutiloption::setLockingRange:
-        LOG(D) << "Setting Locking Range " << (uint16_t) opts.lockingrange << " " << (uint16_t) opts.lockingstate;
-        return d->setLockingRange(opts.lockingrange, opts.lockingstate, argv[opts.password]);
+		LOG(D) << "Setting Locking Range " << (uint16_t) opts.lockingrange << " " << (uint16_t) opts.lockingstate;
+		{
+			uint8_t rc = d->setLockingRange(opts.lockingrange, opts.lockingstate, argv[opts.password]);
+			if (rc == 0 && opts.lockingstate != OPAL_LOCKINGSTATE::LOCKED) {
+				d->rereadPartitionTable();
+			}
+			return rc;
+		}
 		break;
 	case sedutiloption::setLockingRange_SUM:
 		LOG(D) << "Setting Locking Range " << (uint16_t)opts.lockingrange << " " << (uint16_t)opts.lockingstate << " in Single User Mode";
-		return d->setLockingRange_SUM(opts.lockingrange, opts.lockingstate, argv[opts.password]);
+		{
+			uint8_t rc = d->setLockingRange_SUM(opts.lockingrange, opts.lockingstate, argv[opts.password]);
+			if (rc == 0 && opts.lockingstate != OPAL_LOCKINGSTATE::LOCKED) {
+				d->rereadPartitionTable();
+			}
+			return rc;
+		}
 		break;
 	case sedutiloption::enableLockingRange:
         LOG(D) << "Enabling Locking Range " << (uint16_t) opts.lockingrange;

--- a/freebsd/DtaDevOS.cpp
+++ b/freebsd/DtaDevOS.cpp
@@ -47,6 +47,11 @@ unsigned long long DtaDevOS::getSize()
 	return 0;
 }
 
+void DtaDevOS::rereadPartitionTable()
+{
+	LOG(D1) << "rereadPartitionTable: not implemented on FreeBSD";
+}
+
 DtaDevOS::DtaDevOS()
 {
 	drive = NULL;

--- a/freebsd/DtaDevOS.h
+++ b/freebsd/DtaDevOS.h
@@ -58,6 +58,8 @@ protected:
     void identify(OPAL_DiskInfo& disk_info);
     /** return drive size in bytes */
     unsigned long long getSize();
+    /** Re-read partition table after unlock */
+    void rereadPartitionTable();
     int fd; /**< FreeBSD handle for the device  */
 private:
     DtaDevFreeBSDDrive *drive;

--- a/linux/DtaDevOS.cpp
+++ b/linux/DtaDevOS.cpp
@@ -31,6 +31,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <unistd.h>
 #include <linux/hdreg.h>
+#include <linux/fs.h>
 #include <errno.h>
 #include <vector>
 #include <fstream>
@@ -157,6 +158,16 @@ void DtaDevOS::osmsSleep(uint32_t ms)
 {
 	usleep(ms * 1000); //convert to microseconds
     return;
+}
+void DtaDevOS::rereadPartitionTable()
+{
+	if (fd < 0) {
+		LOG(D1) << "rereadPartitionTable: invalid fd";
+		return;
+	}
+	if (ioctl(fd, BLKRRPART, 0) < 0) {
+		LOG(D1) << "BLKRRPART ioctl failed, errno=" << errno;
+	}
 }
 int  DtaDevOS::diskScan()
 {

--- a/linux/DtaDevOS.h
+++ b/linux/DtaDevOS.h
@@ -58,6 +58,8 @@ protected:
     void identify(OPAL_DiskInfo& disk_info);
     /** return drive size in bytes */
     unsigned long long getSize();
+    /** Re-read partition table after successful unlock */
+    void rereadPartitionTable();
     int fd; /**< Linux handle for the device  */
     int isLocked; /** device has LOCK_EX */
 private:

--- a/windows/DtaDevOS.cpp
+++ b/windows/DtaDevOS.cpp
@@ -131,6 +131,11 @@ unsigned long long DtaDevOS::getSize() {
 	return(0);
 }
 
+void DtaDevOS::rereadPartitionTable()
+{
+	LOG(D1) << "rereadPartitionTable: not implemented on Windows";
+}
+
 /** adds the IDENTIFY information to the disk_info structure */
 
 void DtaDevOS::identify(OPAL_DiskInfo& di)

--- a/windows/DtaDevOS.h
+++ b/windows/DtaDevOS.h
@@ -54,6 +54,8 @@ public:
 	* @param bufferlen length of the input/output buffer
 	*/
 	unsigned long long	getSize();
+	/** Re-read partition table after unlock */
+	void rereadPartitionTable();
 	/** A static class to scan for supported drives */
 	static int diskScan();
 protected:


### PR DESCRIPTION
When unlocking FreeBSD-initialized SED drives, middleware makes two unlock attempts: first without -freebsdCompat (fails), then with the flag (succeeds). This creates a race condition in udev's partition reprobing. When the first sedutil closes after failed unlock, udev attempts BLKRRPART (fails with EIO) but still triggers a CHANGE uevent. A udev worker spawns to process this event and acquires LOCK_SH on the device. When the second sedutil closes after successful unlock, udev's manager attempts LOCK_EX for BLKRRPART to reprobe partitions. This fails with EAGAIN due to the worker's LOCK_SH, and since udev has no retry mechanism, partitions never appear. When unlocking multiple disks in parallel, the probability increases that the second sedutil closes while the worker from the first event still holds LOCK_SH, causing approximately 40% of 24 disks to miss partition reprobe.

Given that udev's partition reprobing is unreliable in this scenario, this patch calls BLKRRPART ioctl directly from sedutil immediately after successful unlock. This ensures partitions appear reliably for any readable state (READWRITE, READONLY, ARCHIVEUNLOCKED). Testing shows no additional overhead from this direct reprobing call.

Original PR: https://github.com/truenas/sedutil/pull/15


Original PR: https://github.com/truenas/sedutil/pull/16
